### PR TITLE
feat(runtime): contracts for Scheduler/Context/Runtime API

### DIFF
--- a/graph/runtime/api.lua
+++ b/graph/runtime/api.lua
@@ -1,0 +1,26 @@
+--[[
+Runtime API (fasada)
+--------------------
+Odpowiedzialność:
+- Udostępnia proste wejście do runtime dla reszty aplikacji (gra/edytor).
+- Składa w całość: Scheduler + Context.
+- Nie zawiera logiki „węzłów”.
+
+Pola:
+- scheduler : Scheduler
+- context   : Context
+
+Publiczne API (stub):
+- new(opts) -> Runtime
+  -- opts.scheduler? : Scheduler (dla testów można wstrzyknąć mock)
+  -- opts.context?   : Context
+- on(eventName, entryFn)           -- alias do scheduler.on
+- emit(eventName, payload)         -- start handlerów z domyślnym contextem
+- tick(dt_ms)                      -- alias do scheduler.tick
+- stopAll()
+- setContext(ctx) / getContext()
+
+Uwagi:
+- entryFn ma sygnaturę function(ctx, payload) i POWINIEN być „exec-chain” (może yielduać).
+- Węzły używają helperów (np. runtime.yieldSleep/ms) – do rozważenia jako delegacja do scheduler’a.
+]]

--- a/graph/runtime/context.lua
+++ b/graph/runtime/context.lua
@@ -1,0 +1,19 @@
+--[[
+Context
+-------
+Odpowiedzialność:
+- Przenosi stan wykonania (blackboard) i usługi (services) między węzłami.
+- Nie zna UI; to czysty runtime-owy obiekt.
+
+Pola:
+- blackboard : table    -- współdzielony stan gry/sceny (np. {player={x=..}})
+- services   : table    -- wstrzyknięte serwisy (Input, Audio, Scene, Time, UIBus...)
+
+Publiczne API (stub):
+- new(opts) -> Context
+  -- opts.blackboard? : table
+  -- opts.services?   : table
+- get(name)          -> any      -- skrót do blackboard[name]
+- set(name, value)   -> void
+- service(name)      -> any      -- zwróć services[name] lub błąd jeśli brak
+]]

--- a/graph/runtime/scheduler.lua
+++ b/graph/runtime/scheduler.lua
@@ -1,0 +1,26 @@
+--[[
+Scheduler (Exec + Coroutines)
+-----------------------------
+Odpowiedzialność:
+- Uruchamianie ścieżek „exec” jako korutyn.
+- Harmonogram „sleep” (czas) i „waitUntil” (warunek).
+- Pętla odświeżania: tick(dt).
+- Rejestrowanie handlerów zdarzeń (Start, Timer, KeyDown itp.).
+
+Pola (wewnętrzne):
+- coroutines : { { co=thread, wake=number_ms, cond=function|nil, ctx=table } }
+- nowMs()    : function zwracająca czas w ms (wstrzykiwana / zamienialna dla testów)
+- events     : mapa: eventName -> lista funkcji entry(ctx,payload) (wygenerowane/zbindowane)
+
+Publiczne API (stub):
+- new(opts) -> Scheduler
+  -- opts.nowMs? : function
+- on(eventName, entryFn)            -- zarejestruj handler „entryFn(ctx, payload)”
+- start(eventName, payload, ctx)    -- odpal łańcuch exec jako korutynę
+- tick(dt_ms)                        -- odmraża korutyny, wznawia je; wołane co klatkę
+- stopAll()                          -- zabija wszystkie aktywne korutyny
+
+API dla węzłów (wywoływane Z WEWNĄTRZ korutyny):
+- yieldSleep(ms)         -- coroutine.yield({ type="sleep", t=ms })
+- yieldWaitUntil(fn)     -- coroutine.yield({ type="waitUntil", cond=fn })
+]]


### PR DESCRIPTION
## Co zmienia ten PR?
- Dodaje kontrakty (komentarze, bez implementacji) dla:
  - scheduler.lua (Exec+coroutines, sleep/waitUntil, tick)
  - context.lua (blackboard, services)
  - api.lua (fasada runtime)

## Dlaczego?
- Ustalamy publiczne API runtime przed implementacją.

## Checklist
- [x] Bez logiki/rysowania
- [x] Zgodność z README/planem
