### PR TITLE
Feat/UI contracts update

### DIFF
--- a/graph/runtime/api.lua
+++ b/graph/runtime/api.lua
@@ -1,0 +1,26 @@
+--[[
+Runtime API (fasada)
+--------------------
+Odpowiedzialność:
+- Udostępnia proste wejście do runtime dla reszty aplikacji (gra/edytor).
+- Składa w całość: Scheduler + Context.
+- Nie zawiera logiki „węzłów”.
+
+Pola:
+- scheduler : Scheduler
+- context   : Context
+
+Publiczne API (stub):
+- new(opts) -> Runtime
+  -- opts.scheduler? : Scheduler (dla testów można wstrzyknąć mock)
+  -- opts.context?   : Context
+- on(eventName, entryFn)           -- alias do scheduler.on
+- emit(eventName, payload)         -- start handlerów z domyślnym contextem
+- tick(dt_ms)                      -- alias do scheduler.tick
+- stopAll()
+- setContext(ctx) / getContext()
+
+Uwagi:
+- entryFn ma sygnaturę function(ctx, payload) i POWINIEN być „exec-chain” (może yielduać).
+- Węzły używają helperów (np. runtime.yieldSleep/ms) – do rozważenia jako delegacja do scheduler’a.
+]]

--- a/graph/runtime/context.lua
+++ b/graph/runtime/context.lua
@@ -1,0 +1,19 @@
+--[[
+Context
+-------
+Odpowiedzialność:
+- Przenosi stan wykonania (blackboard) i usługi (services) między węzłami.
+- Nie zna UI; to czysty runtime-owy obiekt.
+
+Pola:
+- blackboard : table    -- współdzielony stan gry/sceny (np. {player={x=..}})
+- services   : table    -- wstrzyknięte serwisy (Input, Audio, Scene, Time, UIBus...)
+
+Publiczne API (stub):
+- new(opts) -> Context
+  -- opts.blackboard? : table
+  -- opts.services?   : table
+- get(name)          -> any      -- skrót do blackboard[name]
+- set(name, value)   -> void
+- service(name)      -> any      -- zwróć services[name] lub błąd jeśli brak
+]]

--- a/graph/runtime/scheduler.lua
+++ b/graph/runtime/scheduler.lua
@@ -1,0 +1,26 @@
+--[[
+Scheduler (Exec + Coroutines)
+-----------------------------
+Odpowiedzialność:
+- Uruchamianie ścieżek „exec” jako korutyn.
+- Harmonogram „sleep” (czas) i „waitUntil” (warunek).
+- Pętla odświeżania: tick(dt).
+- Rejestrowanie handlerów zdarzeń (Start, Timer, KeyDown itp.).
+
+Pola (wewnętrzne):
+- coroutines : { { co=thread, wake=number_ms, cond=function|nil, ctx=table } }
+- nowMs()    : function zwracająca czas w ms (wstrzykiwana / zamienialna dla testów)
+- events     : mapa: eventName -> lista funkcji entry(ctx,payload) (wygenerowane/zbindowane)
+
+Publiczne API (stub):
+- new(opts) -> Scheduler
+  -- opts.nowMs? : function
+- on(eventName, entryFn)            -- zarejestruj handler „entryFn(ctx, payload)”
+- start(eventName, payload, ctx)    -- odpal łańcuch exec jako korutynę
+- tick(dt_ms)                        -- odmraża korutyny, wznawia je; wołane co klatkę
+- stopAll()                          -- zabija wszystkie aktywne korutyny
+
+API dla węzłów (wywoływane Z WEWNĄTRZ korutyny):
+- yieldSleep(ms)         -- coroutine.yield({ type="sleep", t=ms })
+- yieldWaitUntil(fn)     -- coroutine.yield({ type="waitUntil", cond=fn })
+]]

--- a/graph/ui/controller.lua
+++ b/graph/ui/controller.lua
@@ -1,0 +1,26 @@
+--[[
+Controller (Input -> Actions)
+-----------------------------
+Odpowiedzialność:
+- Zbiera wejścia (mysz/klawiatura/gamepad/dotyk) i emituje AKCJE edytora.
+- Nie rysuje, nie wykonuje grafu.
+
+Wejścia:
+- input : abstrakcja wejść (rcore + własne mapowania)
+- hit   : moduł detekcji "co pod kursorem"
+- camera: { ox, oy, zoom }
+
+Akcje (emitowane; przykłady):
+- { type="pan", dx, dy }
+- { type="zoom", scale, pivotX, pivotY }
+- { type="node.dragStart", id, at }
+- { type="node.drag", id, dx, dy }
+- { type="link.begin", nodeId, portName }
+- { type="link.commit", from={...}, to={...} }
+- { type="select.boxStart"/"select.boxEnd" }
+- { type="delete.selection" }
+
+Publiczne API (stub):
+- new(opts) -> Controller
+- update(dt, graph, selection, camera) -> {actions} -- lista akcji do wykonania przez wyższą warstwę (Editor)
+]]

--- a/graph/ui/gestures.lua
+++ b/graph/ui/gestures.lua
@@ -1,0 +1,18 @@
+--[[
+Gestures
+--------
+Odpowiedzialność:
+- Składanie prymitywów wejścia w gesty (drag, click, double-click, pinch-zoom, long-press).
+- Uproszczenie dla Controller.
+
+Publiczne API (stub):
+- update(input, dt) -> {events}
+  -- events: { type="dragStart"/"drag"/"dragEnd", x,y, dx,dy, button },
+            { type="click", x,y, button, count },
+            { type="wheel", delta, x,y },
+            { type="pinch", scale, centerX, centerY },
+            { type="key", code, pressed/released }
+
+Uwagi:
+- Brak bezpośredniej zależności od graph.
+]]

--- a/graph/ui/hit.lua
+++ b/graph/ui/hit.lua
@@ -14,3 +14,161 @@ Publiczne API (stub):
 Uwagi:
 - Współrzędne wejściowe w screen-space; funkcje same przeliczają na world-space albo przyjmują już world.
 ]]
+
+--[[
+Hit (Hit-testing)
+-----------------
+Kontrakty + pseudokod dla detekcji trafień w edytorze grafu.
+
+Założenia:
+- Wejście funkcji przyjmuje współrzędne EKRANOWE (screen-space).
+- Layout odpowiada za geometrię i konwersje: screen<->world, nodeRect, portPosition, linkPath, itp.
+- Theme determinuje tolerancję trafienia (np. szerokość linii linku).
+- rshapes* dostarcza prymitywy kolizyjne (point-rect, point-circle, point-line, recs).
+
+Struktury pomocnicze (przykład):
+selection = { nodes = { [nodeId]=true, ... }, links = { [linkId]=true, ... } }
+camera    = { ox:number, oy:number, zoom:number }
+theme     = { sizes = { portRadius=6, portExecSize=10, linkWidth=2 }, ... }
+
+Wydajność:
+- Zawsze rób pre-check AABB zanim wejdziesz w drogie testy (szczególnie linki).
+- Cache’uj wynik aproksymacji krzywej linku do polyline: link._poly = {p0,p1,...}, link._aabb = {x,y,w,h}
+  i unieważniaj przy ruchu node/port (to zrobi później warstwa UI/Renderer).
+
+API (publiczne):
+- hitNode(graph, x_screen, y_screen, camera, layout)          -> nodeId|nil
+- hitPort(graph, x_screen, y_screen, camera, layout, theme)   -> {nodeId, portName, kind}|nil
+- hitLink(graph, x_screen, y_screen, camera, layout, theme)   -> linkId|nil
+- hitRect(graph, rectWorld, layout)                            -> { nodeIds={...}, linkIds={...} }
+  (Uwaga: hitRect przyjmuje już rect w world-space, bo zwykle pochodzi z box-select liczonego w world.)
+]]
+
+
+-- TODO: wstrzyknij zależności rshapes przez require na górze modułu:
+-- local rshapes = require("rshapes")
+
+
+--[[
+hitNode
+-------
+Cel: zwrócić ID pierwszego (najwyższego) noda pod kursorem.
+
+Kroki:
+1) Przelicz punkt ekranu na świat:
+   local wx, wy = layout.screenToWorld(camera, x_screen, y_screen)
+2) Iteruj po nodach w kolejności od "góry" (jeśli masz Z-order; jeśli nie, w odwrotnej kolejności dodawania).
+3) Dla każdego noda:
+   - local rect = layout.nodeRect(node)  -- {x,y,w,h} w world
+   - if rshapes.CheckCollisionPointRec({x=wx,y=wy}, rect) then return node.id end
+4) Jeśli nic nie trafiono -> nil.
+]]
+function hitNode(graph, x_screen, y_screen, camera, layout)
+  -- stub
+  return nil
+end
+
+
+--[[
+hitPort
+-------
+Cel: znaleźć port (data/exec) pod kursorem.
+
+Kroki:
+1) (wx,wy) = screen->world
+2) Dla każdego node:
+   - Pobierz listę portów: node.inputs + node.outputs
+   - Dla każdego portu:
+     * local px, py = layout.portPosition(node, port) -- środek portu (world)
+     * jeśli port.kind == "data":
+         - promień = theme.sizes.portRadius (np. 6)
+         - if rshapes.CheckCollisionPointCircle({x=wx,y=wy}, {x=px,y=py}, promień) -> trafiony
+     * jeśli port.kind == "exec":
+         - zdefiniuj mały rect wokół (px,py): np. {x=px-s/2, y=py-s/2, w=s, h=s}, gdzie s=theme.sizes.portExecSize
+         - if rshapes.CheckCollisionPointRec({x=wx,y=wy}, rect) -> trafiony
+   - Zwróć pierwsze trafienie: { nodeId=node.id, portName=port.name, kind=port.kind }
+3) Jeśli nic -> nil.
+]]
+function hitPort(graph, x_screen, y_screen, camera, layout, theme)
+  -- stub
+  return nil
+end
+
+
+--[[
+hitLink
+-------
+Cel: kliknięcie w link (krzywa Beziera albo polilinia).
+
+Kroki:
+1) (wx,wy) = screen->world
+2) Zdefiniuj tolerancję trafienia:
+   local tol = (theme.sizes.linkWidth or 2) * 0.6 + 3   -- UX-friendly
+3) Iteruj po linkach:
+   - Szybki pre-check AABB:
+     * local aabb = link._aabb or layout.linkAABB(link, graph)  -- jeśli masz taką funkcję; w przeciwnym razie policz z polyline
+     * jeżeli aabb i rshapes.CheckCollisionPointRec({x=wx,y=wy}, aabb) == false -> pomiń
+   - Weź polyline:
+     * local poly = link._poly
+     * jeśli brak cache: poly = layout.linkPolyline(link, graph) i opcjonalnie policz/cachuj AABB
+   - Iteruj segmenty polyline: (p[i], p[i+1])
+     * if rshapes.CheckCollisionPointLine({x=wx,y=wy}, p[i], p[i+1], tol) -> return link.id
+4) Jeśli nic -> nil.
+
+Uwaga:
+- Jeśli nie masz jeszcze layout.linkPolyline, możesz:
+  * wziąć (p0,c0,c1,p1) = layout.linkPath(link, graph)
+  * zasamplować Bezier w N równych krokach (np. N=16) do polyline.
+- Cache link._poly musi być unieważniany przy:
+  * ruchu któregokolwiek z końców portów albo zmianie geometrii nody.
+]]
+function hitLink(graph, x_screen, y_screen, camera, layout, theme)
+  -- stub
+  return nil
+end
+
+
+--[[
+hitRect
+-------
+Cel: zaznaczenie obszarem (box select). Przyjmujemy rect w world-space.
+
+Parametry:
+- rectWorld = { x, y, w, h } (world)
+
+Kroki:
+1) Zainicjalizuj wyniki: res = { nodeIds={}, linkIds={} }
+2) Nody:
+   - dla każdego noda:
+     * local r = layout.nodeRect(node)
+     * jeśli rshapes.CheckCollisionRecs(r, rectWorld) -> table.insert(res.nodeIds, node.id)
+3) Linki (opcjonalnie – droższe):
+   - Szybki pre-check: aabb linku vs rectWorld → jeśli brak przecięcia, pomiń.
+   - Wykonaj „gęstość punktów testowych” lub szybkie heurystyki:
+     * sprawdź, czy któryś z segmentów polyline przecina granice recta:
+       - np. testuj „segment vs każda krawędź recta” za pomocą rshapes.CheckCollisionLines
+       - lub několka punktów wewnątrz recta: jeżeli point-line <= tol dla któregokolwiek segmentu → trafienie
+   - Jeśli trafiony → table.insert(res.linkIds, link.id)
+4) Zwróć res.
+]]
+function hitRect(graph, rectWorld, layout)
+  -- stub
+  return { nodeIds = {}, linkIds = {} }
+end
+
+
+--[[
+Pomocnicze zalecenia (do implementacji później):
+- Priorytety trafienia: port > link > node (albo node > port — wybierz i trzymaj spójnie).
+- Warstwa "Editor" może robić multi-hit: wywołać najpierw hitPort, jak nil to hitLink, jak nil to hitNode.
+- Kolejność iteracji: jeżeli masz pojęcie Z-order, iteruj od najwyższego.
+- Wszystkie liczby (tol, rozmiary) bierz z theme.sizes; nie zostawiaj „magicznych stałych” w kodzie.
+- Funkcje layoutu:
+  * screenToWorld(camera, sx, sy) -> wx, wy
+  * nodeRect(node) -> {x,y,w,h}
+  * portPosition(node, port) -> {x,y}
+  * linkPath(link, graph) -> {p0,c0,c1,p1}  -- jeżeli używasz Beziera
+  * linkPolyline(link, graph) -> { {x,y}, ... }  -- aproksymacja; N=12..24
+  * linkAABB(link, graph) -> {x,y,w,h}  -- jeśli nie policzysz, da się wyznaczyć z polyline
+]]
+

--- a/graph/ui/hit.lua
+++ b/graph/ui/hit.lua
@@ -1,0 +1,16 @@
+--[[
+Hit (Hit-testing)
+-----------------
+Odpowiedzialność:
+- Odpowiada na pytania: "co jest pod kursorem/punktem/obszarem?"
+- Używany przez Controller.
+
+Publiczne API (stub):
+- hitNode(graph, x, y, camera, layout)   -> nodeId|nil
+- hitPort(graph, x, y, camera, layout)   -> {nodeId, portName, kind}|nil
+- hitLink(graph, x, y, camera)           -> linkId|nil
+- hitRect(graph, rectWorld)              -> { nodeIds = {...}, linkIds = {...} }
+
+Uwagi:
+- Współrzędne wejściowe w screen-space; funkcje same przeliczają na world-space albo przyjmują już world.
+]]

--- a/graph/ui/layout.lua
+++ b/graph/ui/layout.lua
@@ -1,0 +1,15 @@
+--[[
+Layout
+------
+Odpowiedzialność:
+- Geometria nodów i portów: oblicza pozycje portów, rect-y, punkty zaczepienia linków.
+
+Publiczne API (stub):
+- nodeRect(node) -> {x,y,w,h}
+- portPosition(node, port) -> {x,y} (world-space)
+- linkPath(link, graph) -> {p0, p1, c0, c1}  -- np. krzywa Beziera
+- worldToScreen(camera, x,y) / screenToWorld(camera, x,y)
+
+Uwagi:
+- Zero rysowania; tylko matematyka/położenia.
+]]

--- a/graph/ui/renderer.lua
+++ b/graph/ui/renderer.lua
@@ -1,0 +1,26 @@
+--[[
+Renderer (View)
+---------------
+Odpowiedzialność:
+- Rysowanie edytora grafu (grid, nody, porty, linki, selekcje, overlaye).
+- Zero logiki grafu i runtime; tylko prezentacja.
+
+Wejścia (dane wejściowe):
+- graph     : Graph (z core)
+- selection : { nodes = set(nodeId), links = set(linkId) }
+- camera    : { ox, oy, zoom } -- world->screen
+- theme     : Theme
+- layout    : Layout (pozycje portów w nodzie itp.)
+
+Publiczne API (stub):
+- drawGrid(camera, theme)
+- drawGraph(graph, selection, camera, theme, layout)
+- drawNode(node, isSelected, camera, theme, layout)
+- drawPort(node, port, camera, theme, layout)
+- drawLink(link, camera, theme)
+- drawOverlay(info) -- np. podpowiedzi, statusy
+
+Uwagi:
+- Używa rcore/rshapes/rtext/rtextures do rysowania.
+- Nie modyfikuje graph; nic nie zapisuje stanu.
+]]

--- a/graph/ui/theme.lua
+++ b/graph/ui/theme.lua
@@ -1,0 +1,15 @@
+--[[
+Theme
+-----
+Odpowiedzialność:
+- Kolory, grubości, promienie, czcionki, paddingi.
+
+Przykładowe pola:
+- colors = { bg, grid, nodeBg, nodeBorder, portData, portExec, link, selection }
+- sizes  = { nodeRadius, portRadius, portSizeExec, linkWidth }
+- font   = { name, size }
+
+Publiczne API (stub):
+- default() -> Theme
+- with(overrides) -> Theme  -- tworzy kopię z nadpisaniami
+]]


### PR DESCRIPTION
## Co zmienia ten PR?
- [ ]

## Dlaczego?
Krótko: bierzemy rshapes do kolizji wszędzie, gdzie się da, a własny kod tylko tam, gdzie Raylib nie ma gotowca (czyli głównie „trafienie” w krzywe linków). To daje szybkość (C), stabilność i mniej bugów.

Co robimy czym?

1) Nody (prostokąty)

Hit kursora w nodzie → CheckCollisionPointRec.

Zaznaczanie ramką → CheckCollisionRecs (przecięcie rectów).

“Chwyt” krawędzi do resize (jeśli będzie) → też CheckCollisionPointRec na małych rectach-handlach.

2) Porty

Dane (okrąg) → CheckCollisionPointCircle.

Exec (prostokąt) → CheckCollisionPointRec.

3) Linki (krzywe) – jedyne miejsce z własną logiką

Layout daje nam krzywą Beziera (p0,c0,c1,p1).

Aproksymujemy krzywą krótkim polyline (np. 12–24 segmenty).

Dla każdego segmentu używamy CheckCollisionPointLine z tolerancją (grubość linku/2 + margines).
(Ewentualnie szybkie AABB pre-check per segment, żeby ograniczyć wywołania.)

4) Lasso / wielokąt zaznaczenia

Punkt w poligonie → CheckCollisionPointPoly.

Albo dla węzłów – sprawdzamy czy któryś narożnik recta jest w poligonie (wystarczy do UX).

5) Przecięcia linii (użyteczne przy routingu/debugu)

CheckCollisionLines – do wykrywania kolizji prostych odcinków, np. przy narzędziu „prosty link”.

6) Boxy 3D – pomijamy (to tylko dodatki Rayliba; nasz edytor jest 2D).

Dlaczego tak?

Wydajność: rshapes to C – kolizje punkt↔rect/circle/line są tanie i dobrze przetestowane.

Prostota: mniej własnego kodu = mniej regresji.

Elastyczność: linki i tak rysujemy Bezierem, więc aproksymacja polyline + CheckCollisionPointLine to najprostsza i sprawdzona technika (z regulowaną „grubością trafienia”).

Mikro-plan dla graph/ui/hit.lua

Wszystkie funkcje przyjmują screen-coords, pierwsza linia: p_world = layout.screenToWorld(camera, p_screen).

hitNode(graph, x, y, camera, layout)

nodeRect = layout.nodeRect(node) → CheckCollisionPointRec(p_world, nodeRect).

hitPort(graph, x, y, …)

policz portPos = layout.portPosition(node, port),

data: CheckCollisionPointCircle, exec: CheckCollisionPointRec na małym rect przy porcie.

hitLink(graph, x, y, …)

z layout.linkPath(link) weź krzywą → zrób polyline (cache’uj per link + invaliduj przy ruchu),

iteruj segmenty: CheckCollisionPointLine(p_world, a, b, tolerance).

hitRect(graph, rectWorld)

dla nodów: CheckCollisionRecs(nodeRect, rectWorld),

dla linków: szybki test – jeśli AABB polyline’u nie przecina recta, pomiń; w przeciwnym razie sprawdź segmenty CheckCollisionPointLine na siatce punktów z recta (np. rogi + środek krawędzi) lub „segment vs rect” heurystyką.

Uwagi techniczne

Zawsze rób pre-check AABB zanim wejdziesz w droższe testy (szczególnie linki).

Cache: polyline linku trzymaj w polu runtime UI (np. link._poly + link._aabb), unieważniaj gdy ruszy node/port.

Tolerancja: zacznij od t = theme.sizes.linkWidth * 0.6 + 3 px – miły UX przy kliku.

Kiedy pisać „swoje”?

Gdy będziemy chcieli np. hit-test „po grubości” Bezierów dokładnie (bez polyline) albo niestandardowe profile trafienia. To można dodać później, jeśli okaże się potrzebne.

Podsumowanie decyzji

Tak: korzystamy z rshapes do wszystkich prymitywów kolizyjnych w UI grafu.

Własny kod: tylko sampling krzywych linków do polyline + lekka optymalizacja (AABB, cache).

## Testy / Jak sprawdzić?
- [ ]

## Checklist
- [ ] Format/lint
- [ ] Brak zmian w API bez opisu w README/CHANGELOG
